### PR TITLE
랜덤 검색 JPQL 수정 및 멘토 조건 변경

### DIFF
--- a/src/main/java/com/team/cklob/gami/domain/member/repository/MemberDetailRepository.java
+++ b/src/main/java/com/team/cklob/gami/domain/member/repository/MemberDetailRepository.java
@@ -47,7 +47,7 @@ public interface MemberDetailRepository extends JpaRepository<MemberDetail, Long
             "ORDER BY RAND() " +
             "LIMIT 1",
             nativeQuery = true)
-    Optional<MemberDetail> findRandomByMajorAndGenerationLessThanEqual(
+    Optional<MemberDetail> findRandomByMajorAndGenerationLessThan(
             @Param("major") Major major,
             @Param("generation") Integer generation
     );

--- a/src/main/java/com/team/cklob/gami/domain/mentoring/service/impl/RandomSearchServiceImpl.java
+++ b/src/main/java/com/team/cklob/gami/domain/mentoring/service/impl/RandomSearchServiceImpl.java
@@ -28,7 +28,7 @@ public class RandomSearchServiceImpl implements RandomSearchService {
                 .orElseThrow(NotFoundMemberDetailException::new);
 
         MemberDetail mentorDetail = memberDetailRepository
-                .findRandomByMajorAndGenerationLessThanEqual(details.getMajor(), details.getGeneration())
+                .findRandomByMajorAndGenerationLessThan(details.getMajor(), details.getGeneration())
                 .orElseThrow(NotFoundRandomMentorException::new);
 
         return new GetMentorResponse(


### PR DESCRIPTION
## 💡 배경 및 개요

> 런덤 검색 오류로 랜덤 검색 JPQL로 이넘을 받을 수 있게 수정하고, 멘토 조건을 윗 기수로 수정하여 자기자신이 조회되지 않도록 수정하였습니다

Resolves: #40

## 📃 작업내용

> 랜덤 검색 JPQL 수정

## 🙋‍♂️ 리뷰노트

> 오류가 있었던 부분인 만큼 꼼꼼히 봐주세요

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타