### PR TITLE
게시글 삭제 시 FK 제약으로 인한 오류 수정

### DIFF
--- a/src/main/java/com/team/cklob/gami/domain/admin/service/impl/AdminPostServiceImpl.java
+++ b/src/main/java/com/team/cklob/gami/domain/admin/service/impl/AdminPostServiceImpl.java
@@ -1,9 +1,13 @@
 package com.team.cklob.gami.domain.admin.service.impl;
 
 import com.team.cklob.gami.domain.admin.service.AdminPostService;
+import com.team.cklob.gami.domain.comment.repository.CommentRepository;
 import com.team.cklob.gami.domain.post.entity.Post;
 import com.team.cklob.gami.domain.post.exception.NotFoundPostException;
+import com.team.cklob.gami.domain.post.repository.PostImageRepository;
 import com.team.cklob.gami.domain.post.repository.PostRepository;
+import com.team.cklob.gami.domain.postlike.repository.PostLikeRepository;
+import com.team.cklob.gami.domain.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,11 +18,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminPostServiceImpl implements AdminPostService {
 
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final PostImageRepository postImageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final ReportRepository reportRepository;
 
     @Override
     public void deletePost(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(NotFoundPostException::new);
+
+        commentRepository.deleteAllByPostId(postId);
+        postRepository.deleteAllFromLikeTableByPostId(postId);
+        postImageRepository.deleteAllByPostId(postId);
+        postLikeRepository.deleteAllByPostId(postId);
+        reportRepository.deleteAllByPostId(postId);
 
         postRepository.delete(post);
     }

--- a/src/main/java/com/team/cklob/gami/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/team/cklob/gami/domain/comment/repository/CommentRepository.java
@@ -2,10 +2,17 @@ package com.team.cklob.gami.domain.comment.repository;
 
 import com.team.cklob.gami.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByPostIdOrderByCreatedAtAsc(Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Comment c where c.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/team/cklob/gami/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/team/cklob/gami/domain/post/repository/PostImageRepository.java
@@ -2,9 +2,17 @@ package com.team.cklob.gami.domain.post.repository;
 
 import com.team.cklob.gami.domain.post.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
     List<PostImage> findAllByPostId(Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from PostImage pi where pi.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/team/cklob/gami/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/team/cklob/gami/domain/post/repository/PostRepository.java
@@ -39,4 +39,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     void decreaseLike(@Param("postId") Long postId);
 
     List<Post> findAllByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "delete from `like` where post_id = :postId", nativeQuery = true)
+    void deleteAllFromLikeTableByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/team/cklob/gami/domain/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/com/team/cklob/gami/domain/postlike/repository/PostLikeRepository.java
@@ -2,6 +2,9 @@ package com.team.cklob.gami.domain.postlike.repository;
 
 import com.team.cklob.gami.domain.postlike.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +13,8 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByMemberEmailAndPost_Id(String memberEmail, Long postId);
 
     Optional<PostLike> findByMemberEmailAndPost_Id(String memberEmail, Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from PostLike pl where pl.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/team/cklob/gami/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/team/cklob/gami/domain/report/repository/ReportRepository.java
@@ -3,7 +3,9 @@ package com.team.cklob.gami.domain.report.repository;
 import com.team.cklob.gami.domain.report.entity.Report;
 import com.team.cklob.gami.domain.report.entity.constant.ReportType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -22,4 +24,8 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
         JOIN FETCH r.post
     """)
     List<Report> findAllWithReporterAndPost();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Report r where r.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }


### PR DESCRIPTION
## 💡 배경 및 개요

FK 오류 해결
Resolves: #{이슈번호}

## 📃 작업내용

어드민 게시글 삭제 API에서 다른 테이블을 참조하여 생기는 FK 제약 위반 오류를 해결하였습니다
## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타